### PR TITLE
Vagrantfile update:

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Getting started
 ---------------
 * install VirtualBox, Vagrant and ChefDK
 * `vagrant plugin install vagrant-berkshelf`
+* `vagrant plugin install vagrant-omnibus`
 * if you use rbenv or otherwise manipulate your path, make sure you set `/opt/chefdk/bin` ahead of any other locally installed gems that might conflict with berkshelf, foodcritic, etc, e.g.:
 
 ```bash

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,9 +2,10 @@
 # vi: set ft=ruby :
 
 Vagrant.configure('2') do |config|
-  config.vm.hostname = 'pelias'
-  config.vm.box      = 'ubuntu-14.04'
-  config.vm.box_url  = 'https://oss-binaries.phusionpassenger.com/vagrant/boxes/latest/ubuntu-14.04-amd64-vbox.box'
+  config.omnibus.chef_version = '11.12.8'
+  config.vm.hostname          = 'pelias'
+  config.vm.box               = 'ubuntu-14.04-opscode'
+  config.vm.box_url           = 'http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box'
 
   config.vm.provider 'virtualbox' do |v|
     host = RbConfig::CONFIG['host_os']


### PR DESCRIPTION
- new base box -> use opscode box with no default provisioner
- set chef version to 11.12.8 via omnibus plugin. Allows more granular control over chef version
- update README
- requires installation of vagrant-omnibus plugin
