### PR TITLE
- maintain attribute alignment

### DIFF
--- a/cookbooks/pelias/attributes/default.rb
+++ b/cookbooks/pelias/attributes/default.rb
@@ -30,18 +30,18 @@ default[:pelias][:api][:shutdown_timeout]               = 30
 # address-deduper
 default[:pelias][:address_deduper][:repository]         = 'https://github.com/openvenues/address_deduper'
 default[:pelias][:address_deduper][:revision]           = 'master'
-default[:pelias][:address_deduper][:leveldb_dir]        = '/leveldb/address_dedup/db'
+default[:pelias][:address_deduper][:leveldb]            = "#{node[:pelias][:basedir]}/leveldb/address_dedup/db"
 
 # openaddresses
-default[:pelias][:openaddresses][:repository] = 'https://github.com/pelias/openaddresses'
-default[:pelias][:openaddresses][:revision]   = nil
-default[:pelias][:openaddresses][:data_files] = [] # will load all OA
-default[:pelias][:openaddresses][:full_data_url]   = 'http://data.openaddresses.io/openaddresses-complete.zip'
-default[:pelias][:openaddresses][:data_path]   = 'http://data.openaddresses.io.s3.amazonaws.com'
-default[:pelias][:openaddresses][:full_file_name]  = node[:pelias][:openaddresses][:full_data_url].split('/').last
-default[:pelias][:openaddresses][:data_dir]   = "#{node[:pelias][:basedir]}/data/openaddresses"
-default[:pelias][:openaddresses][:index_data] = true
-default[:pelias][:openaddresses][:timeout]    = 172_800 # 48 hours
+default[:pelias][:openaddresses][:repository]           = 'https://github.com/pelias/openaddresses'
+default[:pelias][:openaddresses][:revision]             = 'master'
+default[:pelias][:openaddresses][:data_files]           = [] # will load all OA
+default[:pelias][:openaddresses][:full_data_url]        = 'http://data.openaddresses.io/openaddresses-complete.zip'
+default[:pelias][:openaddresses][:data_path]            = 'http://data.openaddresses.io.s3.amazonaws.com'
+default[:pelias][:openaddresses][:full_file_name]       = node[:pelias][:openaddresses][:full_data_url].split('/').last
+default[:pelias][:openaddresses][:data_dir]             = "#{node[:pelias][:basedir]}/data/openaddresses"
+default[:pelias][:openaddresses][:index_data]           = true
+default[:pelias][:openaddresses][:timeout]              = 172_800 # 48 hours
 
 # geonames
 default[:pelias][:geonames][:repository]                = 'https://github.com/pelias/geonames.git'
@@ -72,7 +72,7 @@ default[:pelias][:osm][:revision]                       = 'master'
 default[:pelias][:osm][:index_data]                     = false
 default[:pelias][:osm][:admin_lookup]                   = false
 default[:pelias][:osm][:timeout]                        = 14_400 # 4 hours
-default[:pelias][:osm][:leveldb]                        = "#{node[:pelias][:basedir]}/leveldb"
+default[:pelias][:osm][:leveldb]                        = "#{node[:pelias][:basedir]}/leveldb/osm"
 default[:pelias][:osm][:extracts]                       = {}
 
 # schema

--- a/cookbooks/pelias/attributes/external.rb
+++ b/cookbooks/pelias/attributes/external.rb
@@ -6,7 +6,7 @@ default[:nodejs][:version]                      = '0.12.2'
 default[:nodejs][:checksum_linux_x64]           = '4e1578efc2a2cc67651413a05ccc4c5d43f6b4329c599901c556f24d93cd0508'
 
 # elasticsearch
-default[:elasticsearch][:version]               = '1.5.2'
+default[:elasticsearch][:version]               = '1.7.0'
 default[:elasticsearch][:skip_restart]          = true
 default[:elasticsearch][:bootstrap][:mlockall]  = false
 default[:elasticsearch][:allocated_memory]      = "#{(node[:memory][:total].to_i * 0.6).floor / 1024}m"

--- a/cookbooks/pelias/recipes/address_deduper.rb
+++ b/cookbooks/pelias/recipes/address_deduper.rb
@@ -5,15 +5,8 @@
 
 include_recipe 'pelias::_address_deduper_service'
 
-directory node[:pelias][:address_deduper][:leveldb_dir] do
-  recursive true
-  owner     node[:pelias][:user][:name]
-  group     node[:pelias][:user][:name]
-  mode      0755
-end
-
 execute 'chown leveldb dir' do
-  command "chown -R #{node[:pelias][:user][:name]}:#{node[:pelias][:user][:name]} /leveldb"
+  command "chown -R #{node[:pelias][:user][:name]}:#{node[:pelias][:user][:name]} #{node[:pelias][:basedir]}/leveldb"
 end
 
 # requirements

--- a/cookbooks/pelias/recipes/openaddresses.rb
+++ b/cookbooks/pelias/recipes/openaddresses.rb
@@ -30,7 +30,7 @@ end
 execute 'purge address deduper datastore' do
   action  :nothing
   user    node[:pelias][:user][:name]
-  command "find #{node[:pelias][:address_deduper][:leveldb_dir]} -type f -exec rm {} \\; || true"
+  command "find #{node[:pelias][:address_deduper][:leveldb]} -type f -exec rm {} \\; || true"
 end
 
 execute 'npm install openaddresses' do

--- a/cookbooks/pelias/recipes/setup.rb
+++ b/cookbooks/pelias/recipes/setup.rb
@@ -60,7 +60,7 @@ directory node[:pelias][:osm][:leveldb] do
 end
 
 # address deduper
-directory [:pelias][:address_deduper][:leveldb] do
+directory node[:pelias][:address_deduper][:leveldb] do
   recursive true
   owner     node[:pelias][:user][:name]
   mode      0755

--- a/cookbooks/pelias/recipes/setup.rb
+++ b/cookbooks/pelias/recipes/setup.rb
@@ -58,3 +58,10 @@ directory node[:pelias][:osm][:leveldb] do
   owner  node[:pelias][:user][:name]
   mode   0755
 end
+
+# address deduper
+directory [:pelias][:address_deduper][:leveldb] do
+  recursive true
+  owner     node[:pelias][:user][:name]
+  mode      0755
+end


### PR DESCRIPTION
- nest deduper leveldb dir under basedir
- move osm leveldb dir to its own location
- move directory setup for deduper into setup.rb just to maintain
  consistency
- update deduper chown for new path as above
- update deduper purge for new path as above