### PR TITLE
changes to support the import pipeline pelias-gtfs

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -33,7 +33,7 @@ GRAPH
     build-essential (>= 0.0.0)
     homebrew (>= 0.0.0)
     yum-epel (>= 0.0.0)
-  pelias (0.6.0)
+  pelias (0.6.1)
     apt (>= 0.0.0)
     elasticsearch (>= 0.0.0)
     java (>= 0.0.0)

--- a/cookbooks/pelias/attributes/default.rb
+++ b/cookbooks/pelias/attributes/default.rb
@@ -75,6 +75,12 @@ default[:pelias][:osm][:timeout]                        = 14_400 # 4 hours
 default[:pelias][:osm][:leveldb]                        = "#{node[:pelias][:basedir]}/leveldb/osm"
 default[:pelias][:osm][:extracts]                       = {}
 
+# gtfs
+default[:pelias][:gtfs][:repository]                    = 'https://github.com/rmaceissoft/pelias-gtfs'
+default[:pelias][:gtfs][:revision]                      = 'master'
+default[:pelias][:gtfs][:stops_url]                     = 'http://<ip_address>/otp/routers/default/index/stops/'
+default[:pelias][:gtfs][:index_data]                    = false
+
 # schema
 default[:pelias][:schema][:repository]                  = 'https://github.com/pelias/schema.git'
 default[:pelias][:schema][:revision]                    = 'master'

--- a/cookbooks/pelias/attributes/default.rb
+++ b/cookbooks/pelias/attributes/default.rb
@@ -80,6 +80,7 @@ default[:pelias][:gtfs][:repository]                    = 'https://github.com/rm
 default[:pelias][:gtfs][:revision]                      = 'master'
 default[:pelias][:gtfs][:stops_url]                     = 'http://<ip_address>/otp/routers/default/index/stops/'
 default[:pelias][:gtfs][:index_data]                    = false
+default[:pelias][:gtfs][:admin_lookup]                  = true
 
 # schema
 default[:pelias][:schema][:repository]                  = 'https://github.com/pelias/schema.git'

--- a/cookbooks/pelias/metadata.rb
+++ b/cookbooks/pelias/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Mapzen'
 maintainer_email 'grant@mapzen.com'
 license          'GPL'
 description      'Installs/configures Pelias in a vagrant environment. Intended for education and development.'
-version          '0.6.0'
+version          '0.6.1'
 
 %w(
   apt

--- a/cookbooks/pelias/recipes/default.rb
+++ b/cookbooks/pelias/recipes/default.rb
@@ -12,6 +12,7 @@
   geonames
   quattroshapes
   osm
+  gtfs
 ).each do |r|
   include_recipe "pelias::#{r}"
 end

--- a/cookbooks/pelias/recipes/gtfs.rb
+++ b/cookbooks/pelias/recipes/gtfs.rb
@@ -1,0 +1,38 @@
+#
+# Cookbook Name:: pelias
+# Recipe:: gtfs
+#
+
+deploy "#{node[:pelias][:basedir]}/gtfs" do
+  user        node[:pelias][:user][:name]
+  repository  node[:pelias][:gtfs][:repository]
+  revision    node[:pelias][:gtfs][:revision]
+  migrate     false
+
+  symlink_before_migrate.clear
+
+  notifies :run, 'execute[npm install gtfs]', :immediately
+  only_if { node[:pelias][:gtfs][:index_data] == true }
+end
+
+execute 'npm install gtfs' do
+  action :nothing
+  user node[:pelias][:user][:name]
+  command 'npm install'
+  cwd "#{node[:pelias][:basedir]}/gtfs/current"
+  environment(
+    'HOME' => node[:pelias][:user][:home]
+  )
+  notifies :run, "execute[import gtfs data]", :immediately
+end
+
+
+execute 'import gtfs data' do
+  action :nothing
+  user node[:pelias][:user][:name]
+  cwd "#{node[:pelias][:basedir]}/gtfs/current"
+  command 'node import.js'
+  environment(
+    'PELIAS_CONFIG' => "#{node[:pelias][:cfg_dir]}/#{node[:pelias][:cfg_file]}"
+  )
+end

--- a/cookbooks/pelias/templates/default/pelias.json.erb
+++ b/cookbooks/pelias/templates/default/pelias.json.erb
@@ -47,6 +47,9 @@
         "type": { "node": "osmnode", "way": "osmway" },
         "filename": "<%= @osm_data_file %>"
       }]
+    },
+    "gtfs": {
+      "stopsurl": "<%= node[:pelias][:gtfs][:stops_url] %>"
     }
   },
   "elasticsearch": {

--- a/cookbooks/pelias/templates/default/pelias.json.erb
+++ b/cookbooks/pelias/templates/default/pelias.json.erb
@@ -49,7 +49,8 @@
       }]
     },
     "gtfs": {
-      "stopsurl": "<%= node[:pelias][:gtfs][:stops_url] %>"
+      "stopsurl": "<%= node[:pelias][:gtfs][:stops_url] %>",
+      "adminLookup": <%= node[:pelias][:gtfs][:admin_lookup] %>
     }
   },
   "elasticsearch": {

--- a/pelias_settings.example.rb
+++ b/pelias_settings.example.rb
@@ -46,6 +46,10 @@ Vagrant.configure('2') do |config|
           'extracts' => {
             'london' => 'https://s3.amazonaws.com/metro-extracts.mapzen.com/london_england.osm.pbf'
           }
+        },
+        'gtfs' => {
+          'index_data' => true,
+          'stops_url' => 'http://<ip_address>/otp/routers/default/index/stops/'
         }
       }
     }


### PR DESCRIPTION
work in progress.

The import pipeline pelias-gtfs (https://github.com/rmaceissoft/pelias-gtfs) is taking the Open Trip Planner REST API (http://dev.opentripplanner.org/apidoc/0.15.0/resource_Routers.html) as source to import the stops, which will only work if you load the GTFS file into an OTP instance.

I'm planning to use the GTFS zip file directly, so we can remove the dependency with OTP

looking for some feedback
