### PR TITLE
update example file to use format specified in the README

### DIFF
--- a/pelias_settings.example.rb
+++ b/pelias_settings.example.rb
@@ -26,7 +26,7 @@ Vagrant.configure('2') do |config|
         'openaddresses' => {
           'index_data' => true,
           'data_files' => [
-            'us/ny/city_of_new_york.csv'
+            'us-ny-nyc'
           ]
         },
         'geonames' => {


### PR DESCRIPTION
resolve #53 `vagrant up` now runs without an errors.